### PR TITLE
Bitmap_idx_rename

### DIFF
--- a/src/alloc.cpp
+++ b/src/alloc.cpp
@@ -40,33 +40,22 @@ LogicalBlockIdx Allocator::alloc(uint32_t num_blocks) {
   }
 
   // then we have to allocate from global bitmaps
-  recent_bitmap_local_idx =
-      Bitmap::alloc_batch(bitmap, NUM_BITMAP, recent_bitmap_local_idx);
+  recent_bitmap_idx =
+      Bitmap::alloc_batch(bitmap, NUM_BITMAP, recent_bitmap_idx);
 
-  // keep this part of code as it may be used in the future for dynamically
-  // growing bitmap while (true) {
-  //   bitmap_block_idx =
-  //       pmem::BitmapBlock::get_bitmap_block_idx(recent_bitmap_block_id);
-  //   bitmap_block = &(mem_table->get(bitmap_block_idx)->bitmap_block);
-  //   recent_bitmap_local_idx = bitmap_block->alloc_batch();
-  //   if (recent_bitmap_local_idx >= 0) goto add_to_free_list;
-  //   recent_bitmap_block_id++;
-  //   recent_bitmap_local_idx = 0;
-  // }
-
-  assert(recent_bitmap_local_idx >= 0);
+  assert(recent_bitmap_idx >= 0);
   // push in decreasing order so pop will in increasing order
-  LogicalBlockIdx allocated = recent_bitmap_local_idx;
+  LogicalBlockIdx allocated_idx = recent_bitmap_idx;
   if (num_blocks < BITMAP_CAPACITY) {
     free_list.emplace_back(BITMAP_CAPACITY - num_blocks,
-                           allocated + num_blocks);
+                           allocated_idx + num_blocks);
     std::sort(free_list.begin(), free_list.end());
   }
   // this recent is not useful because we have taken all bits; move on
-  recent_bitmap_local_idx++;
-  TRACE("Allocator::alloc: allocating from bitmap: [%u, %u)", allocated,
-        num_blocks + allocated);
-  return allocated;
+  recent_bitmap_idx++;
+  TRACE("Allocator::alloc: allocating from bitmap: [%u, %u)", allocated_idx,
+        allocated_idx + num_blocks);
+  return allocated_idx;
 }
 
 void Allocator::free(LogicalBlockIdx block_idx, uint32_t num_blocks) {

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -31,7 +31,7 @@ class Allocator {
   // TODO: this may be useful for dynamically growing bitmap
   // BitmapBlockId recent_bitmap_block_id;
   // NOTE: this is the index within recent_bitmap_block
-  BitmapLocalIdx recent_bitmap_local_idx;
+  BitmapIdx recent_bitmap_idx;
 
   // blocks for storing log entries, max 512 entries per block
   std::vector<LogicalBlockIdx> log_blocks;
@@ -46,7 +46,7 @@ class Allocator {
       : file(file),
         meta(meta),
         bitmap(bitmap),
-        recent_bitmap_local_idx(),
+        recent_bitmap_idx(),
         log_blocks(),
         curr_log_block(nullptr),
         free_log_local_idx(NUM_LOG_ENTRY) {

--- a/src/const.h
+++ b/src/const.h
@@ -43,8 +43,8 @@ constexpr static uint32_t BITMAP_BLOCK_CAPACITY =
 constexpr static uint16_t NUM_BITMAP_PER_BLOCK =
     BLOCK_SIZE / sizeof(dram::Bitmap);
 static_assert(
-    NUM_BITMAP_PER_BLOCK - 1 <= std::numeric_limits<BitmapLocalIdx>::max(),
-    "NUM_BITMAP_PER_BLOCK - 1 should be representable with BitmapLocalIdx");
+    NUM_BITMAP_PER_BLOCK - 1 <= std::numeric_limits<BitmapIdx>::max(),
+    "NUM_BITMAP_PER_BLOCK - 1 should be representable with BitmapIdx");
 
 // we use one hugepage of bitmap, which is sufficient for a 64GB file
 // TODO: extend bitmap dynamically

--- a/src/idx.h
+++ b/src/idx.h
@@ -11,7 +11,7 @@ using LogicalBlockIdx = uint32_t;
 // block index seen by applications
 using VirtualBlockIdx = uint32_t;
 // each bit in the bitmap corresponds to a logical block
-using BitmapLocalIdx = int32_t;
+using BitmapIdx = int32_t;
 // TODO: this may be helpful for dynamically growing DRAM bitmap
 
 // local index within a block; this can be -1 to indicate an error


### PR DESCRIPTION
This renaming is made, because the previous `BitmapLocalIdx` is to indicate the index within a bitmap block, but know we don't allocate from individual blocks but from an array of bitmaps directly. `Local` is meaningless in that sense.