### PR TITLE
Store `shm_path` using xattr

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -8,7 +8,8 @@ namespace ulayfs {
 // signature
 constexpr static int SIGNATURE_SIZE = 8;
 constexpr static char FILE_SIGNATURE[SIGNATURE_SIZE] = "ULAYFS";
-constexpr static uint16_t SHM_NAME_LEN = 40;
+constexpr static char SHM_XATTR_NAME[] = "user.shm_path";
+constexpr static uint16_t SHM_PATH_LEN = 64;
 
 constexpr static uint16_t NUM_CL_PER_BLOCK = BLOCK_SIZE / CACHELINE_SIZE;
 

--- a/src/file.h
+++ b/src/file.h
@@ -36,6 +36,7 @@ class File {
   const bool can_read;
   const bool can_write;
   pthread_spinlock_t spinlock;
+  char shm_path[SHM_PATH_LEN];
 
   // each thread tid has its local allocator
   // the allocator is a per-thread per-file data structure

--- a/test/test_basic.cpp
+++ b/test/test_basic.cpp
@@ -174,6 +174,9 @@ void test_unlink() {
   int fd = open(FILEPATH, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
   assert(fd >= 0);
 
+  rc = close(fd);
+  assert(rc == 0);
+
   rc = unlink(FILEPATH);
   assert(rc == 0);
 


### PR DESCRIPTION
Allows `shm_path` to be read without opening the file. 

c.f.: https://man7.org/linux/man-pages/man7/xattr.7.html