### PR TITLE
cache unused tx_block in allocator

### DIFF
--- a/src/alloc.cpp
+++ b/src/alloc.cpp
@@ -196,4 +196,30 @@ pmem::LogEntry* Allocator::alloc_log_entry(uint32_t num_blocks,
   }
 }
 
+LogicalBlockIdx Allocator::alloc_tx_block(uint32_t seq,
+                                          pmem::Block*& tx_block) {
+  if (avail_tx_block) {
+    tx_block = avail_tx_block;
+    avail_tx_block = nullptr;
+    tx_block->tx_block.set_tx_seq(seq);
+    pmem::persist_cl_fenced(&tx_block->cache_lines[NUM_CL_PER_BLOCK - 1]);
+    return avail_tx_block_idx;
+  }
+
+  LogicalBlockIdx new_block_idx = alloc(1);
+  tx_block = file->lidx_to_addr_rw(new_block_idx);
+  memset(&tx_block->cache_lines[NUM_CL_PER_BLOCK - 1], 0, CACHELINE_SIZE);
+  tx_block->tx_block.set_tx_seq(seq);
+  pmem::persist_cl_unfenced(&tx_block->cache_lines[NUM_CL_PER_BLOCK - 1]);
+  tx_block->zero_init(0, NUM_CL_PER_BLOCK - 1);
+  return new_block_idx;
+}
+
+void Allocator::free_tx_block(LogicalBlockIdx tx_block_idx,
+                              pmem::Block* tx_block) {
+  assert(!avail_tx_block);
+  avail_tx_block_idx = tx_block_idx;
+  avail_tx_block = tx_block;
+}
+
 }  // namespace ulayfs::dram

--- a/src/tx.h
+++ b/src/tx.h
@@ -87,11 +87,13 @@ class TxMgr {
 
   /**
    * @tparam B MetaBlock or TxBlock
-   * @param block the block that needs a next block to be allocated
+   * @param[in] block the block that needs a next block to be allocated
+   * @param[out] new_tx_block the new tx block allocated (can be same as block)
    * @return the block id of the allocated block
    */
   template <class B>
-  LogicalBlockIdx alloc_next_block(B* block) const;
+  LogicalBlockIdx alloc_next_block(B* block,
+                                   pmem::TxBlock*& new_tx_block) const;
 
   /**
    * If the given idx is in an overflow state, update it if allowed.
@@ -136,7 +138,7 @@ class TxMgr {
  private:
   /**
    * Move along the linked list of TxBlock and find the tail. The returned
-   * tail may not be up-to-date due to race conditon. No new blocks will be
+   * tail may not be up-to-date due to race condition. No new blocks will be
    * allocated. If the end of TxBlock is reached, just return NUM_TX_ENTRY as
    * the TxLocalIdx.
    */


### PR DESCRIPTION
Preparing a transaction block is costly: it requires `memset` a block to zero with flush/fence. This PR recycles an unused tx block in the case of CAS fails in `alloc_next_tx_block`.