### PR TITLE
Thread-safe grow for block table

### DIFF
--- a/src/alloc.cpp
+++ b/src/alloc.cpp
@@ -23,19 +23,20 @@ LogicalBlockIdx Allocator::alloc(uint32_t num_blocks) {
     free_lists[num_blocks - 1].pop_back();
     TRACE(
         "Allocator::alloc: allocating from free list (fully consumed): "
-        "[n_blk: %d, lidx: %d]",
-        lidx.get(), num_blocks);
+        "[n_blk: %d, lidx: %u]",
+        num_blocks, lidx.get());
     return lidx;
   }
 
   for (uint32_t n = num_blocks + 1; n <= BITMAP_CAPACITY; ++n) {
     if (!free_lists[n - 1].empty()) {
       LogicalBlockIdx lidx = free_lists[n - 1].back();
+
       free_lists[n - 1].pop_back();
       free_lists[n - num_blocks - 1].push_back(lidx + num_blocks);
       TRACE(
           "Allocator::alloc: allocating from free list (partially consumed): "
-          "[n_blk: %d, lidx: %d] -> [n_blk: %d, lidx: %d]",
+          "[n_blk: %d, lidx: %u] -> [n_blk: %d, lidx: %u]",
           n, lidx.get(), n - num_blocks, lidx.get() + num_blocks);
       return lidx;
     }
@@ -74,19 +75,19 @@ retry:
     if (!is_found && num_right_zeros >= num_blocks) {
       is_found = true;
       allocated_block_idx = allocated_idx + BITMAP_CAPACITY - num_bits_left;
-      TRACE("Allocator::alloc: allocated blocks: [n_blk: %d, lidx: %d]",
+      TRACE("Allocator::alloc: allocated blocks: [n_blk: %d, lidx: %u]",
             num_right_zeros, allocated_block_idx.get());
       if (num_right_zeros > num_blocks) {
         free_lists[num_right_zeros - num_blocks - 1].emplace_back(
             allocated_idx + BITMAP_CAPACITY - num_bits_left + num_blocks);
-        TRACE("Allocator::alloc: unused blocks saved: [n_blk: %d, lidx: %d]",
+        TRACE("Allocator::alloc: unused blocks saved: [n_blk: %d, lidx: %u]",
               num_right_zeros - num_blocks,
               allocated_idx + BITMAP_CAPACITY - num_bits_left + num_blocks);
       }
     } else {
       free_lists[num_right_zeros - 1].emplace_back(
           allocated_idx + BITMAP_CAPACITY - num_bits_left);
-      TRACE("Allocator::alloc: unused blocks saved: [n_blk: %d, lidx: %d]",
+      TRACE("Allocator::alloc: unused blocks saved: [n_blk: %d, lidx: %u]",
             num_right_zeros, allocated_idx + BITMAP_CAPACITY - num_bits_left);
     }
     allocated_bits >>= num_right_zeros;

--- a/src/btable.cpp
+++ b/src/btable.cpp
@@ -55,7 +55,7 @@ uint64_t BlkTable::update(bool do_alloc, bool init_bitmap) {
   return file_size.load(std::memory_order_relaxed);
 }
 
-void BlkTable::resize_to_fit(VirtualBlockIdx idx) {
+void BlkTable::grow_to_fit(VirtualBlockIdx idx) {
   if (table.size() > idx.get()) return;
   // countl_zero counts the number of leading 0-bits
   // if idx is already a pow of 2, it will be rounded to the next pow of 2
@@ -79,7 +79,7 @@ void BlkTable::apply_tx(pmem::TxEntryIndirect tx_entry, LogMgr* log_mgr,
     begin_vidx = curr_entry->begin_vidx;
     num_blocks = curr_entry->num_blocks;
     end_vidx = begin_vidx + num_blocks;
-    resize_to_fit(end_vidx);
+    grow_to_fit(end_vidx);
 
     for (uint32_t offset = 0; offset < curr_entry->num_blocks; ++offset)
       table[begin_vidx.get() + offset] =
@@ -102,7 +102,7 @@ void BlkTable::apply_tx(pmem::TxEntryInline tx_commit_inline_entry) {
   VirtualBlockIdx begin_vidx = tx_commit_inline_entry.begin_virtual_idx;
   LogicalBlockIdx begin_lidx = tx_commit_inline_entry.begin_logical_idx;
   VirtualBlockIdx end_vidx = begin_vidx + num_blocks;
-  resize_to_fit(end_vidx);
+  grow_to_fit(end_vidx);
 
   // update block table mapping
   for (uint32_t i = 0; i < num_blocks; ++i)

--- a/src/const.h
+++ b/src/const.h
@@ -27,6 +27,7 @@ constexpr static uint32_t GROW_UNIT_SIZE = 1 << GROW_UNIT_SHIFT;
 // preallocate must be multiple of grow_unit
 constexpr static uint32_t PREALLOC_SHIFT = 1 * GROW_UNIT_SHIFT;
 constexpr static uint32_t PREALLOC_SIZE = 1 * GROW_UNIT_SIZE;
+constexpr static uint32_t NUM_BLOCKS_PER_GROW = GROW_UNIT_SIZE >> BLOCK_SHIFT;
 
 /*
  * tx entry

--- a/src/mtable.h
+++ b/src/mtable.h
@@ -19,7 +19,6 @@ constexpr static uint32_t GROW_UNIT_IN_BLOCK_SHIFT =
     GROW_UNIT_SHIFT - BLOCK_SHIFT;
 constexpr static uint32_t GROW_UNIT_IN_BLOCK_MASK =
     (1 << GROW_UNIT_IN_BLOCK_SHIFT) - 1;
-constexpr static uint32_t NUM_BLOCKS_PER_GROW = GROW_UNIT_SIZE >> BLOCK_SHIFT;
 
 // map LogicalBlockIdx into memory address
 // this is a more low-level data structure than Allocator

--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -547,7 +547,8 @@ TxMgr::WriteTx::WriteTx(File* file, TxMgr* tx_mgr, const char* buf,
   uint32_t rest_num_blocks = num_blocks;
   while (rest_num_blocks > 0) {
     uint32_t chunk_num_blocks = std::min(rest_num_blocks, BITMAP_CAPACITY);
-    dst_lidxs.push_back(allocator->alloc(chunk_num_blocks));
+    auto lidx = allocator->alloc(chunk_num_blocks);
+    dst_lidxs.push_back(lidx);
     rest_num_blocks -= chunk_num_blocks;
   }
   assert(!dst_lidxs.empty());


### PR DESCRIPTION
The concurrent growth methods for `tbb::concurrent_vector` (e.g., `grow_by`, `grow_to_at_least`) returns when the elements are allocated, __*but does not guarantee that all elements are constructed*__. See  https://github.com/oneapi-src/oneTBB/issues/241, [an old blog post](https://web.archive.org/web/20100103204609/http://software.intel.com/en-us/blogs/2009/04/09/delusion-of-tbbconcurrent_vectors-size-or-3-ways-to-traverse-in-parallel-correctly/), and [docs](https://spec.oneapi.io/versions/0.6.0/elements/oneTBB/source/containers/concurrent_vector/concurrent_growth.html). 

This PR fixes the issue by using a custom allocator for `tbb::concurrent_vector`
