### PR TITLE
Minor changes on `const.h`

### DIFF
--- a/src/block.h
+++ b/src/block.h
@@ -28,7 +28,7 @@ class BaseBlock {
 };
 
 class TxBlock : public BaseBlock {
-  std::atomic<TxEntry> tx_entries[NUM_TX_ENTRY];
+  std::atomic<TxEntry> tx_entries[NUM_TX_ENTRY_PER_BLOCK];
   // next is placed after tx_entires so that it could be flushed with tx_entries
   std::atomic<LogicalBlockIdx> next;
   // seq is used to construct total order between tx entries, so it must
@@ -40,7 +40,7 @@ class TxBlock : public BaseBlock {
 
  public:
   TxLocalIdx find_tail(TxLocalIdx hint = 0) const {
-    return TxEntry::find_tail<NUM_TX_ENTRY>(tx_entries, hint);
+    return TxEntry::find_tail<NUM_TX_ENTRY_PER_BLOCK>(tx_entries, hint);
   }
 
   TxEntry try_append(TxEntry entry, TxLocalIdx idx) {
@@ -53,7 +53,7 @@ class TxBlock : public BaseBlock {
   }
 
   [[nodiscard]] TxEntry get(TxLocalIdx idx) const {
-    assert(idx >= 0 && idx < NUM_TX_ENTRY);
+    assert(idx >= 0 && idx < NUM_TX_ENTRY_PER_BLOCK);
     return tx_entries[idx].load(std::memory_order_acquire);
   }
 
@@ -83,7 +83,7 @@ class TxBlock : public BaseBlock {
    */
   void flush_tx_block(TxLocalIdx begin_idx = 0) {
     persist_unfenced(&tx_entries[begin_idx],
-                     sizeof(TxEntry) * (NUM_TX_ENTRY - begin_idx) +
+                     sizeof(TxEntry) * (NUM_TX_ENTRY_PER_BLOCK - begin_idx) +
                          2 * sizeof(LogicalBlockIdx));
   }
 

--- a/src/const.h
+++ b/src/const.h
@@ -3,8 +3,6 @@
 #include <cstdint>
 #include <limits>
 
-#include "idx.h"
-
 namespace ulayfs {
 /*
  * hardware
@@ -30,13 +28,17 @@ constexpr static uint32_t PREALLOC_SIZE = 1 * GROW_UNIT_SIZE;
 constexpr static uint32_t NUM_BLOCKS_PER_GROW = GROW_UNIT_SIZE >> BLOCK_SHIFT;
 
 /*
+ * block index
+ */
+constexpr static uint16_t VIRTUAL_BLOCK_IDX_SIZE = 4;
+constexpr static uint16_t LOGICAL_BLOCK_IDX_SIZE = 4;
+
+/*
  * tx entry
  */
 constexpr static uint16_t TX_ENTRY_SIZE = 8;
-constexpr static uint16_t NUM_TX_ENTRY =
-    (BLOCK_SIZE - 2 * sizeof(LogicalBlockIdx)) / TX_ENTRY_SIZE;
-static_assert(NUM_TX_ENTRY - 1 <= std::numeric_limits<TxLocalIdx>::max(),
-              "NUM_TX_ENTRY - 1 should be representable with TxLocalIdx");
+constexpr static uint16_t NUM_TX_ENTRY_PER_BLOCK =
+    (BLOCK_SIZE - 2 * LOGICAL_BLOCK_IDX_SIZE) / TX_ENTRY_SIZE;
 
 // inline data structure count in meta block
 constexpr static uint16_t NUM_TX_ENTRY_PER_CL = CACHELINE_SIZE / TX_ENTRY_SIZE;
@@ -60,9 +62,6 @@ constexpr static uint64_t BITMAP_CAPACITY_IN_BYTES = BITMAP_CAPACITY
 // total number of bitmaps in DRAM
 // TODO: enable dynamic growing of bitmap
 constexpr static uint16_t NUM_BITMAP_PER_BLOCK = BLOCK_SIZE / BITMAP_SIZE;
-static_assert(
-    NUM_BITMAP_PER_BLOCK - 1 <= std::numeric_limits<BitmapIdx>::max(),
-    "NUM_BITMAP_PER_BLOCK - 1 should be representable with BitmapIdx");
 
 // we use one hugepage of bitmap, which is sufficient for a 64GB file
 // TODO: extend bitmap dynamically

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -236,8 +236,7 @@ int File::fsync() {
   // (and thus not flushed) yet, so we cannot assume it is equivalent to the
   // first index of the next block
   // here we use the last index of the block to enforce reflush later
-  uint16_t capacity =
-      tail_tx_idx.block_idx == 0 ? NUM_INLINE_TX_ENTRY : NUM_TX_ENTRY;
+  uint16_t capacity = tail_tx_idx.get_capacity();
   if (unlikely(tail_tx_idx.local_idx >= capacity))
     tail_tx_idx.local_idx = capacity - 1;
   meta->set_tx_tail(tail_tx_idx);

--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -130,7 +130,7 @@ pmem::TxEntry TxMgr::try_commit(pmem::TxEntry entry, TxEntryIdx& tx_idx,
 bool TxMgr::handle_idx_overflow(TxEntryIdx& tx_idx, pmem::TxBlock*& tx_block,
                                 bool do_alloc) const {
   const bool is_inline = tx_idx.is_inline();
-  uint16_t capacity = is_inline ? NUM_INLINE_TX_ENTRY : NUM_TX_ENTRY;
+  uint16_t capacity = tx_idx.get_capacity();
   if (unlikely(tx_idx.local_idx >= capacity)) {
     LogicalBlockIdx block_idx =
         is_inline ? meta->get_next_tx_block() : tx_block->get_next_tx_block();

--- a/src/tx.h
+++ b/src/tx.h
@@ -71,7 +71,7 @@ class TxMgr {
   [[nodiscard]] pmem::TxEntry get_entry_from_block(
       TxEntryIdx idx, pmem::TxBlock* tx_block) const {
     assert(idx.local_idx <
-           (idx.block_idx == 0 ? NUM_INLINE_TX_ENTRY : NUM_TX_ENTRY));
+           (idx.block_idx == 0 ? NUM_INLINE_TX_ENTRY : NUM_TX_ENTRY_PER_BLOCK));
     if (idx.block_idx == 0) return meta->get_tx_entry(idx.local_idx);
     return tx_block->get(idx.local_idx);
   }

--- a/test/test_rw.cpp
+++ b/test/test_rw.cpp
@@ -7,7 +7,7 @@
 
 using ulayfs::BLOCK_SIZE;
 using ulayfs::NUM_INLINE_TX_ENTRY;
-using ulayfs::NUM_TX_ENTRY;
+using ulayfs::NUM_TX_ENTRY_PER_BLOCK;
 
 struct TestOpt {
   int num_bytes_per_iter = BLOCK_SIZE;
@@ -104,7 +104,7 @@ int main() {
   test({.num_bytes_per_iter = BLOCK_SIZE - 8, .init_offset = 8});
   test({.num_bytes_per_iter = BLOCK_SIZE / 2, .init_offset = BLOCK_SIZE / 2});
   test({.num_bytes_per_iter = 8,
-        .num_iter = NUM_INLINE_TX_ENTRY + NUM_TX_ENTRY + 1});
+        .num_iter = NUM_INLINE_TX_ENTRY + NUM_TX_ENTRY_PER_BLOCK + 1});
   test({.num_bytes_per_iter = 8, .num_iter = BLOCK_SIZE / 8});
   test({.num_bytes_per_iter = 8, .num_iter = BLOCK_SIZE * 2 / 8});
   test({.num_bytes_per_iter = 9, .num_iter = BLOCK_SIZE / 9});


### PR DESCRIPTION
`const.h` no longer depends on other internal headers (e.g., `idx.h`) 